### PR TITLE
Build target changed to es5

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "outDir": "build/compiled",
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
-        "target": "ES2019",
+        "target": "es5",
         "module": "commonjs",
         "moduleResolution": "node",
         "importHelpers": true,


### PR DESCRIPTION
Because of how Warthog generates files that are using TypeORM, we need to build the typescript files into `es5` to prevent the TS2499 error.